### PR TITLE
Adaptation for RS Airy Lidar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ Log/*.png
 Log/*.txt
 Log/*.csv
 Log/*.pdf
+Log/*.bag
 .vscode/c_cpp_properties.json
 .vscode/settings.json
 PCD/*.pcd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,8 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   pcl_ros
   tf
+  tf2_ros
+  tf2
   livox_ros_driver
   message_generation
   eigen_conversions
@@ -88,5 +90,7 @@ catkin_package(
 )
 
 add_executable(fastlio_mapping src/laserMapping.cpp include/ikd-Tree/ikd_Tree.cpp src/preprocess.cpp)
+# add_executable(lidar_imu_tf src/tf_broadcaster.cpp)
 target_link_libraries(fastlio_mapping ${catkin_LIBRARIES} ${PCL_LIBRARIES} ${PYTHON_LIBRARIES})
+# target_link_libraries(lidar_imu_tf ${catkin_LIBRARIES})
 target_include_directories(fastlio_mapping PRIVATE ${PYTHON_INCLUDE_DIRS})

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,9 @@ RUN mkdir -p /catkin_ws/src
 WORKDIR /catkin_ws/src
 
 # 4. Clone FAST-LIO ROS Package (RS-Airy branch)
-RUN git clone --branch RS-Airy https://github.com/Ilyes-Origamist/robosense_fast_lio.git
+RUN git clone --branch RS-Airy https://github.com/Ilyes-Origamist/robosense_fast_lio.git && \
+    cd robosense_fast_lio && \
+    git submodule update --init --recursive
 
 # 5. Install drivers
 # Clone the livox_ros_driver

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,88 @@
+# --- Dockerfile for running FAST-LIO with Robosense Airy LiDAR on ROS Noetic ---
+
+# Use ROS Noetic
+FROM osrf/ros:noetic-desktop-full
+
+# Set environment variables for the build system
+ENV ROS_DISTRO=noetic
+ENV ROS_VERSION=1
+
+SHELL ["/bin/bash", "-c"]
+
+# 1. Install System Dependencies & Math Libraries for FAST-LIO
+RUN apt-get update && apt-get install -y \
+    git build-essential cmake wget nano \
+    # Common dependencies for ROS and LiDAR processing (PCL)
+    libpcap-dev libyaml-cpp-dev libpcl-dev \
+    # Networking tools for testing and debugging
+    iputils-ping net-tools iproute2 ethtool tcpdump \
+    # FAST-LIO / SLAM Dependencies
+    libgoogle-glog-dev libgflags-dev \
+    libatlas-base-dev libsuitesparse-dev \
+    # Standard ROS Noetic packages
+    ros-noetic-roscpp ros-noetic-roslib ros-noetic-pcl-ros \
+    ros-noetic-sensor-msgs ros-noetic-std-msgs \
+    ros-noetic-tf ros-noetic-eigen-conversions \
+    ros-noetic-message-generation ros-noetic-message-runtime \
+    && rm -rf /var/lib/apt/lists/*
+
+# 2. Install Ceres Solver (Required by many FAST-LIO versions)
+RUN git clone https://github.com/ceres-solver/ceres-solver.git && \
+    cd ceres-solver && git checkout 1.14.0 && \
+    mkdir build && cd build && cmake .. && make -j$(nproc) && make install && \
+    cd ../.. && rm -rf ceres-solver
+
+# Install Livox SDK system-wide
+RUN git clone https://github.com/Livox-SDK/Livox-SDK.git /tmp/Livox-SDK && \
+    cd /tmp/Livox-SDK/build && \
+    cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release && \
+    make -j$(nproc) && \
+    make install && \
+    echo "/usr/local/lib" >> /etc/ld.so.conf.d/livox.conf && \
+    ldconfig && \
+    rm -rf /tmp/Livox-SDK
+
+# 3. Create Workspace
+RUN mkdir -p /catkin_ws/src
+WORKDIR /catkin_ws/src
+
+# 4. Clone FAST-LIO ROS Package (RS-Airy branch)
+RUN git clone --branch RS-Airy https://github.com/Ilyes-Origamist/robosense_fast_lio.git
+
+# 5. Install drivers
+# Clone the livox_ros_driver
+RUN git clone https://github.com/Livox-SDK/livox_ros_driver.git
+
+# Clone RoboSense SDK with submodules
+RUN git clone https://github.com/RoboSense-LiDAR/rslidar_sdk.git && \
+    cd rslidar_sdk && \
+    git submodule init && \
+    git submodule update
+
+# 6. Configure SDK using your CMakeLists logic
+# Patch CMakeLists.txt compile flags (enable transform, IMU data and set message type)
+RUN cd rslidar_sdk && \
+    sed -i 's/option(ENABLE_TRANSFORM "Enable transform functions" OFF)/option(ENABLE_TRANSFORM "Enable transform functions" ON)/g' CMakeLists.txt && \
+    sed -i 's/option(ENABLE_IMU_DATA_PARSE           "Enable imu data parse" OFF)/option(ENABLE_IMU_DATA_PARSE "Enable imu data parse" ON)/g' CMakeLists.txt && \
+    sed -i 's/set(POINT_TYPE XYZI)/set(POINT_TYPE XYZIRT)/g' CMakeLists.txt
+
+# 7. Get the updated config file inside '/config' (lidar type, min and max range) 
+RUN wget -O /catkin_ws/src/rslidar_sdk/config/config.yaml \
+    https://raw.githubusercontent.com/Ilyes-Origamist/robosense_fast_lio/RS-Airy/config/rslidar_sdk_cfg.yaml
+# COPY catkin_ws/src/rslidar_sdk/config/config.yaml /catkin_ws/src/robosense_fast_lio/config/rslidar_sdk_cfg.yaml
+
+# OR MOUNT THE WHOLE DIRECTORY IN THE DOCKER RUN COMMAND 
+# (THIS WILL OVERWRITE THE DIRECTORY BUT NEED TO COMPILE INSIDE THE DOCKER CONTAINER):
+# docker run -v ~/catkin_ws/src/rslidar_sdk:/catkin_ws/src/rslidar_sdk/ rs_fast_lio
+
+# 8. Build Workspace
+WORKDIR /catkin_ws
+RUN source /opt/ros/noetic/setup.bash && \
+    catkin_make -DCMAKE_BUILD_TYPE=Release
+
+# 9. Finalize Environment
+RUN echo "source /opt/ros/noetic/setup.bash" >> ~/.bashrc && \
+    echo "source /catkin_ws/devel/setup.bash" >> ~/.bashrc
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,67 @@
+
+## Fix By Ilyes (RS-Airy)
+
+Prerequisites:    
+- PCL >= 1.8, Follow PCL Installation.
+- Eigen >= 3.3.4, Follow Eigen Installation.
+
+### Features
+This release adds support for the RS Airy Lidar as additional lidar type `lidar_type: 5`.  
+- Correct frame convention (FLU) for IEKF to work properly, which avoids drift and frame misalignment.     
+- Supports both message types `XYZI` and `XYZIRT` for the RS Airy Lidar.  
+- Supports processing sub-clouds only if message type `XYZIRT`. It is enabled/disabled via parameter `divide_sub_cloud`.
+- Deskewing can be unabled/disabled via parameter `deskew_en`.
+- Applies height filtering to ignore points above `max_height` (ceiling filter), supported for both RS M1 and Airy Lidars. This avoids processing unnecessary points and reduces overhead.
+
+### Notes    
+a. When data type is `XYZI`:       
+- Uses voxel downsampling (PCL) with a voxel size `0.1m x 0.1m x 0.1m`.
+- Assumes all points have the same timestamp (curvature = 0) as a flash scan.
+
+b. When data type is `XYZIRT`:     
+- Uses `robosenseM1_handler`
+- Still applies height filtering
+
+c. Common:
+- NED-to-FLU is performed on the IMU data (y and z axis are inverted) and on the IMU-to-Lidar extrinsics.
+- Replaced hardcoded detection range with parameters from YAML config.
+- Voxel downsampling uses `ApproximateVoxelGrid` for faster downsampling.
+
+**Get Lidar-to-IMU Extrinsics**     
+To get the Lidar-to-IMU extrinsics from DIFOP packet, first set the parameter `send_packet_ros` to true in `rs_lidar`, then record the topic `/rslidar_packets` using rosbag. Finally, run the suggested script `extract_packet_data.py` to convert to numerical values and get three translations and a quaternion (which you need to convert to a rotation matrix).     
+
+### How to Run (Docker)
+**Build an image**      
+First build a Docker image using the suggested Dockerfile:
+```sh
+docker build -t ros_noetic_fast_lio "https://github.com/Ilyes-Origamist/robosense_fast_lio.git#RS-Airy"
+```
+Note that it is not needed to clone the repository locally.
+
+**Create a Docker Container**        
+Before running, grant the container access to the host X11 display server, allowing GUI applications like RViz to render on your screen:
+```sh
+xhost +local:docker
+```
+or
+```sh
+echo "xhost +local:docker" >> ~/.bashrc
+```
+for persistent change.
+
+Then run the container using:
+```sh
+docker run -it --rm \
+  --privileged \
+  --net=host \
+  --env DISPLAY=$DISPLAY \
+  --env QT_X11_NO_MITSHM=1 \
+  -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
+#   -v ~/catkin_ws/rosbags/march24_XYZIRT_test2.bag:/catkin_ws/test.bag \
+  --name rs_fast_lio \
+  ros_noetic_fast_lio
+```
+
 ## Adaption by ruanjy
 
 Support the robosense LiDARs including **M1, E1R, and Airy**

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ c. Common:
 - Voxel downsampling uses `ApproximateVoxelGrid` for faster downsampling.
 
 **Get Lidar-to-IMU Extrinsics**     
-To get the Lidar-to-IMU extrinsics from DIFOP packet, first set the parameter `send_packet_ros` to true in `rs_lidar`, then record the topic `/rslidar_packets` using rosbag. Finally, run the suggested script `extract_packet_data.py` to convert to numerical values and get three translations and a quaternion (which you need to convert to a rotation matrix).     
+To get the Lidar-to-IMU extrinsics from DIFOP packet, first set the parameter `send_packet_ros` to true in `rslidar_sdk`, then record the topic `/rslidar_packets` using rosbag. Finally, run the suggested script `extract_packet_data.py` to convert to numerical values and get three translations and a quaternion (which you need to convert to a rotation matrix).     
 
 ### How to Run (Docker)
 **Build an image**      
@@ -57,9 +57,12 @@ docker run -it --rm \
   --env DISPLAY=$DISPLAY \
   --env QT_X11_NO_MITSHM=1 \
   -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
-#   -v ~/catkin_ws/rosbags/march24_XYZIRT_test2.bag:/catkin_ws/test.bag \
   --name rs_fast_lio \
   ros_noetic_fast_lio
+```
+You can mount a .bag file using the `-v` flag by adding the line:
+```sh
+  -v /path/to/host/file.bag:/catkin_ws/data.bag \
 ```
 
 ## Adaption by ruanjy

--- a/config/robosenseAiry.yaml
+++ b/config/robosenseAiry.yaml
@@ -23,12 +23,14 @@ mapping:
                                   # false: process the whole point cloud together.
     # Supported for Lidar type 4 (RSM1), and for type 5 (RSAIRY) only if message type is XYZIRT. 
     num_sub_cloud: 1
+    point_filter_num: 1         # 0: no filter; 1: keep all points; 2: keep 1/2 points; 3: keep 1/3 points, and so on.
     acc_cov: 0.05
     gyr_cov: 0.05
-    b_acc_cov: 0.001
-    b_gyr_cov: 0.001
+    b_acc_cov: 0.0002
+    b_gyr_cov: 0.0002
     fov_degree:    360
-    det_range:     100.0
+    det_range:     10.0
+    max_height:    3.0
     extrinsic_est_en:  false      # true: enable the online estimation of IMU-LiDAR extrinsic
     extrinsic_T: [0.004250, 0.004180, -0.004460]
     extrinsic_R: [0.0033883,  -0.99997669,  0.00592802,

--- a/config/robosenseAiry.yaml
+++ b/config/robosenseAiry.yaml
@@ -4,15 +4,24 @@ common:
     time_sync_en: false         # ONLY turn on when external time synchronization is really not possible
     time_offset_lidar_to_imu: 0.0 # Time offset between lidar and IMU calibrated by other algorithms, e.g. LI-Init (can be found in README).
                                   # This param will take effect no matter what time_sync_en is. So if the time offset is not known exactly, please set as 0.0
-
+    deskew_en: false            # true: perform motion compensation for each point; false: skip motion compensation and directly use the input point cloud 
+                               # (assumed to be captured in a flash way, i.e., all points have the same timestamp)
+    # IMPORTANT: if using XYRI, set deskew to false (can deskew only if message type is XYZIRT)
 preprocess:
     lidar_type: 5                # 1 for Livox serials LiDAR, 2 for Velodyne LiDAR, 3 for ouster LiDAR,
+                                 # 4 for Robosense M1 and 5 for Robosense Airy (supports both XYZI and XYZIRT).
+    # IMPORTANT: 4 can work with RS Airy but ONLY IF message type is XYZIRT (change it in CMakeLists.txt in rslidar_sdk)
+    # RS Airy handler actually calls RS M1 handler if message type is XYZIRT. 
+    # If message type is XYZI, it will use voxel downsampling (RS Airy handler).
     scan_line: 96
     timestamp_unit: 0                 # 0-second, 1-milisecond, 2-microsecond, 3-nanosecond.
     blind: 0.1
 
 mapping:
     max_search_dist_surf: 1.0 # default: 5
+    divide_sub_cloud: false       # true: divide the point cloud into several sub-clouds according to the scan line ID, and process them separately; 
+                                  # false: process the whole point cloud together.
+    # Supported for Lidar type 4 (RSM1), and for type 5 (RSAIRY) only if message type is XYZIRT. 
     num_sub_cloud: 1
     acc_cov: 0.05
     gyr_cov: 0.05
@@ -25,16 +34,7 @@ mapping:
     extrinsic_R: [0.0033883,  -0.99997669,  0.00592802,
                  -0.99999315, -0.00339705, -0.00146638,
                   0.00148648, -0.00592301, -0.99998135]
-    # extrinsic_T: [ 0.0, 0.0, 0.0 ]
-    # extrinsic_R: [1, 0, 0,
-    #               0, 1, 0,
-    #               0, 0, 1]
-    # extrinsic_R: [0, 1, 0,
-    #               1, 0, 0,
-    #               0, 0, 1]
-    # extrinsic_R: [0, -1, 0,
-    #               -1, 0, 0,
-    #               0, 0, -1]
+
 publish:
     path_en:  true
     scan_publish_en:  true       # false: close all the point cloud output

--- a/config/robosenseAiry.yaml
+++ b/config/robosenseAiry.yaml
@@ -4,7 +4,7 @@ common:
     time_sync_en: false         # ONLY turn on when external time synchronization is really not possible
     time_offset_lidar_to_imu: 0.0 # Time offset between lidar and IMU calibrated by other algorithms, e.g. LI-Init (can be found in README).
                                   # This param will take effect no matter what time_sync_en is. So if the time offset is not known exactly, please set as 0.0
-    deskew_en: false            # true: perform motion compensation for each point; false: skip motion compensation and directly use the input point cloud 
+    deskew_en: true            # true: perform motion compensation for each point; false: skip motion compensation and directly use the input point cloud 
                                # (assumed to be captured in a flash way, i.e., all points have the same timestamp)
     # IMPORTANT: if using XYRI, set deskew to false (can deskew only if message type is XYZIRT)
 preprocess:
@@ -28,9 +28,17 @@ mapping:
     gyr_cov: 0.05
     b_acc_cov: 0.0002
     b_gyr_cov: 0.0002
+
+    # Tuned parameters (should be inflated). Above parameters worked better
+    # # TAKE THE SQUARE OF NOISE PARAMETERS PROVIDED BY imu_utils. Use SI units (m/s^2 for acceleration, rad/s for angular velocity) for noise parameters.
+    # acc_cov: 4.8416471004107629e-05
+    # gyr_cov: 1.5404300896170346e-06
+    # b_acc_cov: 1.7326989557807598e-08
+    # b_gyr_cov: 3.9576754011393061e-10
+
     fov_degree:    360
     det_range:     10.0
-    max_height:    3.0
+    max_height:    2.5
     extrinsic_est_en:  false      # true: enable the online estimation of IMU-LiDAR extrinsic
     extrinsic_T: [0.004250, 0.004180, -0.004460]
     extrinsic_R: [0.0033883,  -0.99997669,  0.00592802,

--- a/config/robosenseAiry.yaml
+++ b/config/robosenseAiry.yaml
@@ -1,6 +1,6 @@
 common:
     lid_topic:  "/rslidar_points"
-    imu_topic:  "/imu/data" # /mavros/imu/data /ouster/imu /imu/data
+    imu_topic:  "/rslidar_imu_data" # /mavros/imu/data /ouster/imu /imu/data
     time_sync_en: false         # ONLY turn on when external time synchronization is really not possible
     time_offset_lidar_to_imu: 0.0 # Time offset between lidar and IMU calibrated by other algorithms, e.g. LI-Init (can be found in README).
                                   # This param will take effect no matter what time_sync_en is. So if the time offset is not known exactly, please set as 0.0
@@ -9,23 +9,32 @@ preprocess:
     lidar_type: 5                # 1 for Livox serials LiDAR, 2 for Velodyne LiDAR, 3 for ouster LiDAR,
     scan_line: 96
     timestamp_unit: 0                 # 0-second, 1-milisecond, 2-microsecond, 3-nanosecond.
-    blind: 0
+    blind: 0.1
 
 mapping:
     max_search_dist_surf: 1.0 # default: 5
     num_sub_cloud: 1
-    acc_cov: 0.1
-    gyr_cov: 0.1
-    b_acc_cov: 0.0001
-    b_gyr_cov: 0.0001
-    fov_degree:    120
-    det_range:     200.0
+    acc_cov: 0.05
+    gyr_cov: 0.05
+    b_acc_cov: 0.001
+    b_gyr_cov: 0.001
+    fov_degree:    360
+    det_range:     100.0
     extrinsic_est_en:  false      # true: enable the online estimation of IMU-LiDAR extrinsic
-    extrinsic_T: [ 0.0, 0.0, 0.0 ]
-    extrinsic_R: [1, 0, 0,
-                  0, 1, 0,
-                  0, 0, 1]
-
+    extrinsic_T: [0.004250, 0.004180, -0.004460]
+    extrinsic_R: [0.0033883,  -0.99997669,  0.00592802,
+                 -0.99999315, -0.00339705, -0.00146638,
+                  0.00148648, -0.00592301, -0.99998135]
+    # extrinsic_T: [ 0.0, 0.0, 0.0 ]
+    # extrinsic_R: [1, 0, 0,
+    #               0, 1, 0,
+    #               0, 0, 1]
+    # extrinsic_R: [0, 1, 0,
+    #               1, 0, 0,
+    #               0, 0, 1]
+    # extrinsic_R: [0, -1, 0,
+    #               -1, 0, 0,
+    #               0, 0, -1]
 publish:
     path_en:  true
     scan_publish_en:  true       # false: close all the point cloud output

--- a/config/robosenseM1.yaml
+++ b/config/robosenseM1.yaml
@@ -4,6 +4,8 @@ common:
     time_sync_en: false         # ONLY turn on when external time synchronization is really not possible
     time_offset_lidar_to_imu: 0.0 # Time offset between lidar and IMU calibrated by other algorithms, e.g. LI-Init (can be found in README).
                                   # This param will take effect no matter what time_sync_en is. So if the time offset is not known exactly, please set as 0.0
+    deskew_en: true            # true: perform motion compensation for each point; false: skip motion compensation and directly use the input point cloud 
+                               # (assumed to be captured in a flash way, i.e., all points have the same timestamp)
 
 preprocess:
     lidar_type: 5                # 1 for Livox serials LiDAR, 2 for Velodyne LiDAR, 3 for ouster LiDAR,
@@ -13,6 +15,8 @@ preprocess:
 
 mapping:
     max_search_dist_surf: 1.0 # default: 5
+    divide_sub_cloud: false       # true: divide the point cloud into several sub-clouds according to the scan line ID, and process them separately; 
+                                  # false: process the whole point cloud together.
     num_sub_cloud: 1
     acc_cov: 0.1
     gyr_cov: 0.1

--- a/config/rslidar_sdk_cfg.yaml
+++ b/config/rslidar_sdk_cfg.yaml
@@ -1,0 +1,44 @@
+common:
+  msg_source: 1                         # 0: not use Lidar
+                                        # 1: packet message comes from online Lidar
+                                        # 2: packet message comes from ROS or ROS2
+                                        # 3: packet message comes from Pcap file
+  send_packet_ros: false                # true: Send packets through ROS or ROS2(Used to record packet)
+  send_point_cloud_ros: true            # true: Send point cloud through ROS or ROS2
+lidar:
+  - driver:
+      lidar_type: RSAIRY           #  LiDAR type - RS16, RS32, RSBP, RSAIRY, RSHELIOS, RSHELIOS_16P, RS128, RS80, RS48, RSP128, RSP80, RSP48, 
+                                   #               RSM1, RSM1_JUMBO, RSM2, RSM3, RSE1, RSMX.
+                                   
+      msop_port: 6699              #  Msop port of lidar
+      difop_port: 7788             #  Difop port of lidar
+      imu_port: 6688               #  IMU port of lidar(only for RSAIRY, RSE1), 0 means no imu.
+                                   #  If you want to use IMU, please first set ENABLE_IMU_DATA_PARSE to ON in CMakeLists.txt 
+      user_layer_bytes: 0          #  Bytes of user layer. thers is no user layer if it is 0         
+      tail_layer_bytes: 0          #  Bytes of tail layer. thers is no tail layer if it is 0
+
+
+      min_distance: 0.1            #  Minimum distance of point cloud
+      max_distance: 60.0            #  Maximum distance of point cloud
+      use_lidar_clock: true        #  true--Use the lidar clock as the message timestamp
+                                   #  false-- Use the system clock as the timestamp
+      dense_points: true          #  true: discard NAN points; false: reserve NAN points
+      
+      ts_first_point: true         #  true: time-stamp point cloud with the first point; false: with the last point;   
+                                   #  these parameters are used from mechanical lidar
+
+      start_angle: 0             #  Start angle of point cloud
+      end_angle: 360               #  End angle of point cloud
+
+                                   #  When msg_source is 3, the following parameters will be used
+      pcap_repeat: true            #  true: The pcap bag will repeat play   
+      pcap_rate: 1.0               #  Rate to read the pcap file
+      pcap_path: /home/robosense/lidar.pcap #The path of pcap file
+
+    ros:
+      ros_frame_id: rslidar                           #Frame id of packet message and point cloud message
+      ros_recv_packet_topic: /rslidar_packets          #Topic used to receive lidar packets from ROS
+      ros_send_packet_topic: /rslidar_packets          #Topic used to send lidar packets through ROS
+      ros_send_imu_data_topic: /rslidar_imu_data         #Topic used to send imu data through ROS
+      ros_send_point_cloud_topic: /rslidar_points      #Topic used to send point cloud through ROS
+      ros_queue_length: 100                            #Topic QoS history depth

--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,8 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>tf</build_depend>
+  <build_depend>tf2</build_depend>
+  <build_depend>tf2_ros</build_depend>
   <build_depend>pcl_ros</build_depend>
   <build_depend>livox_ros_driver</build_depend>
   <build_depend>message_generation</build_depend>
@@ -35,6 +37,8 @@
   <run_depend>rospy</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>tf</run_depend>
+  <run_depend>tf2</run_depend>
+  <run_depend>tf2_ros</run_depend>
   <run_depend>pcl_ros</run_depend>
   <run_depend>livox_ros_driver</run_depend>
   <run_depend>message_runtime</run_depend>

--- a/rviz_cfg/loam_livox.rviz
+++ b/rviz_cfg/loam_livox.rviz
@@ -6,20 +6,15 @@ Panels:
       Expanded:
         - /Global Options1
         - /Status1
-        - /Grid1
-        - /mapping1
         - /mapping1/currPoints1
         - /mapping1/currPoints1/Autocompute Value Bounds1
-        - /Odometry1
         - /Odometry1/Odometry1
         - /Odometry1/Odometry1/Shape1
         - /Odometry1/Odometry1/Covariance1
         - /Odometry1/Odometry1/Covariance1/Position1
         - /Odometry1/Odometry1/Covariance1/Orientation1
-        - /Path1
-        - /MarkerArray1/Namespaces1
       Splitter Ratio: 0.6432291865348816
-    Tree Height: 1767
+    Tree Height: 871
   - Class: rviz/Selection
     Name: Selection
   - Class: rviz/Tool Properties
@@ -35,7 +30,6 @@ Panels:
     Name: Views
     Splitter Ratio: 0.5
   - Class: rviz/Time
-    Experimental: false
     Name: Time
     SyncMode: 0
     SyncSource: currPoints
@@ -64,12 +58,14 @@ Visualization Manager:
       Plane Cell Count: 1000
       Reference Frame: <Fixed Frame>
       Value: true
-    - Class: rviz/Axes
+    - Alpha: 1
+      Class: rviz/Axes
       Enabled: false
       Length: 0.699999988079071
       Name: Axes
       Radius: 0.05999999865889549
       Reference Frame: <Fixed Frame>
+      Show Trail: false
       Value: false
     - Class: rviz/Group
       Displays:
@@ -182,6 +178,7 @@ Visualization Manager:
           Keep: 1
           Name: Odometry
           Position Tolerance: 0.0010000000474974513
+          Queue Size: 10
           Shape:
             Alpha: 1
             Axes Length: 1
@@ -195,14 +192,16 @@ Visualization Manager:
           Topic: /Odometry
           Unreliable: false
           Value: true
-      Enabled: true
+      Enabled: false
       Name: Odometry
-    - Class: rviz/Axes
+    - Alpha: 1
+      Class: rviz/Axes
       Enabled: false
       Length: 0.699999988079071
       Name: Axes
       Radius: 0.10000000149011612
-      Reference Frame: <Fixed Frame>
+      Reference Frame: body
+      Show Trail: false
       Value: false
     - Alpha: 0
       Buffer Length: 2
@@ -221,6 +220,7 @@ Visualization Manager:
         Z: 0
       Pose Color: 25; 255; 255
       Pose Style: None
+      Queue Size: 10
       Radius: 0.029999999329447746
       Shaft Diameter: 0.4000000059604645
       Shaft Length: 0.4000000059604645
@@ -239,7 +239,7 @@ Visualization Manager:
       Color: 255; 255; 255
       Color Transformer: Intensity
       Decay Time: 0
-      Enabled: false
+      Enabled: true
       Invert Rainbow: false
       Max Color: 239; 41; 41
       Max Intensity: 0
@@ -250,12 +250,20 @@ Visualization Manager:
       Queue Size: 10
       Selectable: true
       Size (Pixels): 4
-      Size (m): 0.30000001192092896
+      Size (m): 0.05000000074505806
       Style: Spheres
-      Topic: /cloud_effected
+      Topic: /rslidar_points
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: true
+      Value: true
+    - Class: rviz/MarkerArray
+      Enabled: false
+      Marker Topic: /MarkerArray
+      Name: MarkerArray
+      Namespaces:
+        {}
+      Queue Size: 100
       Value: false
     - Alpha: 1
       Autocompute Intensity Bounds: true
@@ -285,14 +293,6 @@ Visualization Manager:
       Use Fixed Frame: true
       Use rainbow: true
       Value: false
-    - Class: rviz/MarkerArray
-      Enabled: false
-      Marker Topic: /MarkerArray
-      Name: MarkerArray
-      Namespaces:
-        {}
-      Queue Size: 100
-      Value: false
     - Alpha: 1
       Autocompute Intensity Bounds: true
       Autocompute Value Bounds:
@@ -321,6 +321,32 @@ Visualization Manager:
       Use Fixed Frame: true
       Use rainbow: true
       Value: false
+    - Class: rviz/TF
+      Enabled: true
+      Filter (blacklist): ""
+      Filter (whitelist): ""
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        body:
+          Value: true
+        camera_init:
+          Value: true
+        rslidar:
+          Value: true
+      Marker Alpha: 1
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        camera_init:
+          body:
+            rslidar:
+              {}
+      Update Interval: 0
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 0; 0; 0
@@ -349,33 +375,33 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz/Orbit
-      Distance: 16.798694610595703
+      Distance: 5.150442123413086
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
+      Field of View: 0.7853981852531433
       Focal Point:
-        X: 1.196502923965454
-        Y: 0.9967100024223328
-        Z: 0.31080541014671326
+        X: 1.0770100355148315
+        Y: -0.17695438861846924
+        Z: 0.7562985420227051
       Focal Shape Fixed Size: true
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 1.5697963237762451
+      Pitch: 0.32479724287986755
       Target Frame: global
-      Value: Orbit (rviz)
-      Yaw: 4.856808662414551
+      Yaw: 2.571800947189331
     Saved: ~
 Window Geometry:
   Displays:
     collapsed: false
-  Height: 2033
+  Height: 1016
   Hide Left Dock: false
   Hide Right Dock: true
-  QMainWindow State: 000000ff00000000fd00000004000000000000027d00000755fc020000000dfb0000001200530065006c0065006300740069006f006e00000001e10000009b000000b000fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed0000043c00000185000000b0fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000006e000007550000018200fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d0061006700650000000297000001dc0000000000000000fb0000000a0049006d0061006700650000000394000001600000000000000000fb0000000a0049006d00610067006501000002c5000000c70000000000000000fb0000000a0049006d00610067006501000002c5000000c70000000000000000fb0000000a0049006d00610067006501000002c5000000c70000000000000000000000010000015f00000755fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000006e000007550000013200fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e1000001970000000300000e8000000060fc0100000002fb0000000800540069006d0065000000000000000e80000008d800fffffffb0000000800540069006d0065010000000000000450000000000000000000000bdb0000075500000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd00000004000000000000027d000003a2fc020000000dfb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed0000038800000185000000b0fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003b000003a2000000c700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d0061006700650000000297000001dc0000000000000000fb0000000a0049006d0061006700650000000394000001600000000000000000fb0000000a0049006d00610067006501000002c5000000c70000000000000000fb0000000a0049006d00610067006501000002c5000000c70000000000000000fb0000000a0049006d00610067006501000002c5000000c70000000000000000000000010000015f00000755fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000006e00000755000000a000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e1000001970000000300000e8000000060fc0100000002fb0000000800540069006d0065000000000000000e800000035c00fffffffb0000000800540069006d00650100000000000004500000000000000000000004b7000003a200000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:
@@ -384,6 +410,6 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: true
-  Width: 3684
-  X: 156
-  Y: 55
+  Width: 1850
+  X: 70
+  Y: 27

--- a/src/IMU_Processing.hpp
+++ b/src/IMU_Processing.hpp
@@ -37,6 +37,8 @@ class ImuProcess
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   ImuProcess();
+  ImuProcess(bool deskew_en);
+
   ~ImuProcess();
   
   void Reset();
@@ -62,6 +64,7 @@ class ImuProcess
   V3D cov_bias_gyr;
   V3D cov_bias_acc;
   double first_lidar_time;
+  bool deskew_en{true};
 
  private:
   void IMU_init(const MeasureGroup &meas, esekfom::esekf<state_ikfom, 12, input_ikfom> &kf_state, int &N);
@@ -88,7 +91,11 @@ class ImuProcess
 };
 
 ImuProcess::ImuProcess()
-    : b_first_frame_(true), imu_need_init_(true), start_timestamp_(-1)
+    : ImuProcess(false)
+{}
+
+ImuProcess::ImuProcess(bool deskew_en)
+    : b_first_frame_(true), imu_need_init_(true), start_timestamp_(-1), deskew_en(deskew_en)
 {
   init_iter_num = 1;
   Q = process_noise_cov();
@@ -267,7 +274,13 @@ void ImuProcess::UndistortPcl(const MeasureGroup &meas, esekfom::esekf<state_ikf
   
   /*** sort point clouds by offset time ***/
   pcl_out = *(meas.lidar);
-  sort(pcl_out.points.begin(), pcl_out.points.end(), time_list);
+  // Only sort the point cloud if deskew is enabled 
+  // If disabled, assume scan is flash, aka all points have the same timestamp, so no need to sort (curvature = 0)
+  // and backward propagation will not be performed. (this can save a lot of time for large point clouds, e.g., 128-line lidar with 300k points per scan) 
+  if (deskew_en)
+  {
+    sort(pcl_out.points.begin(), pcl_out.points.end(), time_list);
+  }
 /*    cout<<setprecision(18)<<"[ IMU Process ]: Process "<<meas.lidar->points.size()<<" lidar from "<<pcl_beg_time<<" to "<<pcl_end_time<<", " \
             <<meas.imu.size()<<" imu msgs from "<<imu_beg_time<<" to "<<imu_end_time<<endl;*/
 
@@ -345,6 +358,10 @@ void ImuProcess::UndistortPcl(const MeasureGroup &meas, esekfom::esekf<state_ikf
   last_lidar_end_time_ = pcl_end_time;
 
   /*** undistort each lidar point (backward propagation) ***/
+  // if deskew is disabled, skip the undistortion process (backward propagation) and directly return the input point cloud 
+  // (assumed to be captured in a flash way, i.e., all points have the same timestamp)
+  if (!deskew_en) return;
+  
   if (pcl_out.points.begin() == pcl_out.points.end()) return;
   auto it_pcl = pcl_out.points.end() - 1;
   for (auto it_kp = IMUpose.end() - 1; it_kp != IMUpose.begin(); it_kp--)

--- a/src/IMU_Processing.hpp
+++ b/src/IMU_Processing.hpp
@@ -424,6 +424,8 @@ void ImuProcess::Process(const MeasureGroup &meas,  esekfom::esekf<state_ikfom, 
       cov_acc *= pow(G_m_s2 / mean_acc.norm(), 2);
       imu_need_init_ = false;
 
+      // std::cout << "Cov acc: " << cov_acc.transpose() << std::endl;
+      // std::cout << "Cov gyr: " << cov_gyr.transpose() << std::endl;
       cov_acc = cov_acc_scale;
       cov_gyr = cov_gyr_scale;
       ROS_INFO("IMU Initial Done");

--- a/src/extract_packet_data.py
+++ b/src/extract_packet_data.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+import rosbag
+import struct
+# from scipy.spatial.transform import Rotation as R
+import sys
+
+# bag_path = "/catkin_ws/2026-03-12-11-43-27.bag"
+
+def extract_imu_calibration(bag_path):
+    print(f"Opening {bag_path}...")
+    
+    # The expected DIFOP header sequence
+    difop_header = (0xA5, 0xFF, 0x00, 0x5A, 0x11, 0x11, 0x55, 0x55)
+    
+    with rosbag.Bag(bag_path, 'r') as bag:
+        for topic, msg, t in bag.read_messages(topics=['/rslidar_packets']):
+            
+            # Check if the driver flagged it as DIFOP, or if the header matches
+            if msg.is_difop or tuple(msg.data[0:8]) == difop_header:
+                print("Found DIFOP Packet!")
+                
+                # Double check the length just in case
+                if len(msg.data) < 1092 + 28:
+                    print("Packet too short, skipping...")
+                    continue
+                
+                # Extract the 28 bytes at offset 1092
+                calib_bytes = bytearray(msg.data[1092:1092+28])
+                
+                # Unpack the bytes into 7 little-endian floats ('<7f')
+                # Format: q_x, q_y, q_z, q_w, x, y, z
+                # DIFOP uses big-endian
+                values = struct.unpack('>7f', calib_bytes)
+                qx, qy, qz, qw, x, y, z = values
+                
+                print("\n--- Raw Calibration Values ---")
+                print(f"Quaternion (x, y, z, w): {qx:.6f}, {qy:.6f}, {qz:.6f}, {qw:.6f}")
+                print(f"Translation (x, y, z):   {x:.6f}, {y:.6f}, {z:.6f}")
+                
+                # Convert Quaternion to 3x3 Rotation Matrix
+                # scipy expects [x, y, z, w]
+                # rot = R.from_quat([qx, qy, qz, qw])
+                # rot_matrix = rot.as_matrix()
+                
+                # print("\n--- FAST-LIO YAML Configuration ---")
+                # print("mapping:")
+                # print(f"  extrinsic_T: [{x:.6f}, {y:.6f}, {z:.6f}]")
+                # print("  extrinsic_R: [{:.6f}, {:.6f}, {:.6f},".format(rot_matrix[0][0], rot_matrix[0][1], rot_matrix[0][2]))
+                # print("                {:.6f}, {:.6f}, {:.6f},".format(rot_matrix[1][0], rot_matrix[1][1], rot_matrix[1][2]))
+                # print("                {:.6f}, {:.6f}, {:.6f}]".format(rot_matrix[2][0], rot_matrix[2][1], rot_matrix[2][2]))
+                
+                # We only need one DIFOP packet, so we can stop here
+                return
+
+    print("Finished reading bag. No valid DIFOP packet found.")
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python3 extract_difop.py <path_to_your_rosbag.bag>")
+    else:
+        extract_imu_calibration(sys.argv[1])

--- a/src/laserMapping.cpp
+++ b/src/laserMapping.cpp
@@ -923,6 +923,7 @@ int main(int argc, char** argv)
     nh.param<double>("filter_size_map",filter_size_map_min,0.5);
     nh.param<double>("cube_side_length",cube_len,200);
     nh.param<float>("mapping/det_range",DET_RANGE,300.f);
+    nh.param<double>("mapping/max_height",p_pre->max_height,5.0f);
     nh.param<double>("mapping/fov_degree",fov_deg,180);
     nh.param<double>("mapping/gyr_cov",gyr_cov,0.1);
     nh.param<double>("mapping/acc_cov",acc_cov,0.1);
@@ -945,7 +946,8 @@ int main(int argc, char** argv)
     nh.param<vector<double>>("mapping/extrinsic_T", extrinT, vector<double>());
     nh.param<vector<double>>("mapping/extrinsic_R", extrinR, vector<double>());
     cout<<"p_pre->lidar_type "<<p_pre->lidar_type<<endl;
-    
+    p_pre->det_range = DET_RANGE;
+
     path.header.stamp    = ros::Time::now();
     path.header.frame_id ="camera_init";
     ROS_INFO("--- LiDAR type: %d, Divide into %d sub-clouds: %s", p_pre->lidar_type, num_sub_cloud, p_pre->divide_sub_cloud ? "true" : "false");

--- a/src/laserMapping.cpp
+++ b/src/laserMapping.cpp
@@ -163,6 +163,29 @@ inline void dump_lio_state_to_log(FILE *fp)
     fprintf(fp, "\r\n");  
     fflush(fp);
 }
+void imuToLidarTf()
+{
+    static tf::TransformBroadcaster br;
+    tf::Transform transform;
+
+    transform.setOrigin(tf::Vector3(
+        Lidar_T_wrt_IMU(0),
+        Lidar_T_wrt_IMU(1),
+        Lidar_T_wrt_IMU(2)
+    ));
+
+    tf::Matrix3x3 R_tf(
+        Lidar_R_wrt_IMU(0,0), Lidar_R_wrt_IMU(0,1), Lidar_R_wrt_IMU(0,2),
+        Lidar_R_wrt_IMU(1,0), Lidar_R_wrt_IMU(1,1), Lidar_R_wrt_IMU(1,2),
+        Lidar_R_wrt_IMU(2,0), Lidar_R_wrt_IMU(2,1), Lidar_R_wrt_IMU(2,2)
+    );
+    ros::Time tf_stamp = odomAftMapped.header.stamp;  // or ros::Time::now() if odometry is realtime
+
+    transform.setBasis(R_tf);
+    br.sendTransform(
+        tf::StampedTransform(transform, tf_stamp, "body", "rslidar")
+    );
+}
 
 void pointBodyToWorld_ikfom(PointType const * const pi, PointType * const po, state_ikfom &s)
 {
@@ -360,6 +383,16 @@ void imu_cbk(const sensor_msgs::Imu::ConstPtr &msg_in)
 //    time_diff_lidar_to_imu = -1740105883.56 + 2676.403183080;
 //     time_diff_lidar_to_imu =  -1740106128.69180 + 2919.403164000;// - 0.077;
 //    time_diff_lidar_to_imu =  -1740106128.7678;
+
+    // FIRST, CHANGE IMU FRAME TO FLU IF NED IS USED (RSAIRY)
+    if (p_pre->lidar_type == RSM1_BREAK)
+    {
+        msg->angular_velocity.y *= -1.0;
+        msg->angular_velocity.z *= -1.0;
+        
+        msg->linear_acceleration.y *= -1.0;
+        msg->linear_acceleration.z *= -1.0;
+    }
 
     msg->header.stamp = ros::Time().fromSec(msg_in->header.stamp.toSec() + time_diff_lidar_to_imu);
 
@@ -683,18 +716,18 @@ void publish_odometry(const ros::Publisher & pubOdomAftMapped)
         odomAftMapped.pose.covariance[i*6 + 5] = P(k, 2);
     }
 
-//    static tf::TransformBroadcaster br;
-//    tf::Transform                   transform;
-//    tf::Quaternion                  q;
-//    transform.setOrigin(tf::Vector3(odomAftMapped.pose.pose.position.x, \
-//                                    odomAftMapped.pose.pose.position.y, \
-//                                    odomAftMapped.pose.pose.position.z));
-//    q.setW(odomAftMapped.pose.pose.orientation.w);
-//    q.setX(odomAftMapped.pose.pose.orientation.x);
-//    q.setY(odomAftMapped.pose.pose.orientation.y);
-//    q.setZ(odomAftMapped.pose.pose.orientation.z);
-//    transform.setRotation( q );
-//    br.sendTransform( tf::StampedTransform( transform, odomAftMapped.header.stamp, "camera_init", "body" ) );
+   static tf::TransformBroadcaster br;
+   tf::Transform                   transform;
+   tf::Quaternion                  q;
+   transform.setOrigin(tf::Vector3(odomAftMapped.pose.pose.position.x, \
+                                   odomAftMapped.pose.pose.position.y, \
+                                   odomAftMapped.pose.pose.position.z));
+   q.setW(odomAftMapped.pose.pose.orientation.w);
+   q.setX(odomAftMapped.pose.pose.orientation.x);
+   q.setY(odomAftMapped.pose.pose.orientation.y);
+   q.setZ(odomAftMapped.pose.pose.orientation.z);
+   transform.setRotation( q );
+   br.sendTransform( tf::StampedTransform( transform, odomAftMapped.header.stamp, "camera_init", "body" ) );
 }
 
 void publish_path(const ros::Publisher pubPath)
@@ -898,6 +931,16 @@ int main(int argc, char** argv)
 
     Lidar_T_wrt_IMU<<VEC_FROM_ARRAY(extrinT);
     Lidar_R_wrt_IMU<<MAT_FROM_ARRAY(extrinR);
+    // for RSAIRY, the lidar frame is NED, need to change to FLU
+    if (p_pre->lidar_type == RSM1_BREAK)
+    {
+        M3D NED_to_FLU;
+        NED_to_FLU << 1, 0, 0,
+                    0,-1, 0,
+                    0, 0,-1;
+        Lidar_R_wrt_IMU *= NED_to_FLU;
+    }
+
     p_imu->set_extrinsic(Lidar_T_wrt_IMU, Lidar_R_wrt_IMU);
     p_imu->set_gyr_cov(V3D(gyr_cov, gyr_cov, gyr_cov));
     p_imu->set_acc_cov(V3D(acc_cov, acc_cov, acc_cov));
@@ -1063,6 +1106,7 @@ int main(int argc, char** argv)
 
             /******* Publish odometry *******/
             publish_odometry(pubOdomAftMapped);
+            imuToLidarTf();
 
             /*** add the feature points to map kdtree ***/
             t3 = omp_get_wtime();

--- a/src/laserMapping.cpp
+++ b/src/laserMapping.cpp
@@ -96,6 +96,8 @@ int    iterCount = 0, feats_down_size = 0, NUM_MAX_ITERATIONS = 0, laserCloudVal
 bool   point_selected_surf[100000] = {0};
 bool   lidar_pushed, flg_first_scan = true, flg_exit = false, flg_EKF_inited;
 bool   scan_pub_en = false, dense_pub_en = false, scan_body_pub_en = false;
+bool   deskew_en = true;
+bool   msg_is_XYZI = true, msg_is_XYZIRT = false;
 
 vector<vector<int>>  pointSearchInd_surf; 
 vector<BoxPointType> cub_needrm;
@@ -139,7 +141,7 @@ geometry_msgs::Quaternion geoQuat;
 geometry_msgs::PoseStamped msg_body_pose;
 
 shared_ptr<Preprocess> p_pre(new Preprocess());
-shared_ptr<ImuProcess> p_imu(new ImuProcess());
+shared_ptr<ImuProcess> p_imu(new ImuProcess(deskew_en));
 
 void SigHandle(int sig)
 {
@@ -302,6 +304,25 @@ void lasermap_fov_segment()
 
 void standard_pcl_cbk(const sensor_msgs::PointCloud2::ConstPtr &msg) 
 {
+    // Check LiDAR message type (XYZI or XYZIRT) and print info (only for the first received message)
+    static bool fields_checked = false;
+    if (!fields_checked)
+    {
+        if (msg->fields.size() == 4){
+            msg_is_XYZI = true;
+            ROS_INFO("LiDAR message type: XYZI, with %d points", msg->width * msg->height);
+        }
+        else if (msg->fields.size() >= 6){
+            msg_is_XYZIRT = true;
+            ROS_INFO("LiDAR message type: XYZIRT, with %d points", msg->width * msg->height);
+        }
+        else
+        {
+            ROS_ERROR("Unsupported LiDAR message type, only XYZI and XYZIRT supported");
+            return;
+        }
+        fields_checked = true;
+    }
     //std::cout << "standard_pcl_cbk" << msg->header.stamp.toSec() << std::endl;
     mtx_buffer.lock();
     scan_count ++;
@@ -312,7 +333,9 @@ void standard_pcl_cbk(const sensor_msgs::PointCloud2::ConstPtr &msg)
         lidar_buffer.clear();
     }
 
-    if(p_pre->lidar_type == RSM1_BREAK){
+    if(p_pre->divide_sub_cloud && 
+        (p_pre->lidar_type == RSM1 || (p_pre->lidar_type == RSAIRY && msg_is_XYZIRT)) ) // divide into subclouds only support RSM1 and RSAIRY with XYZIRT message type
+    {
         double start_time, end_time;
         for(int i_sub_cloud = 0; i_sub_cloud < num_sub_cloud; i_sub_cloud ++){
             PointCloudXYZI::Ptr  ptr(new PointCloudXYZI());
@@ -385,7 +408,7 @@ void imu_cbk(const sensor_msgs::Imu::ConstPtr &msg_in)
 //    time_diff_lidar_to_imu =  -1740106128.7678;
 
     // FIRST, CHANGE IMU FRAME TO FLU IF NED IS USED (RSAIRY)
-    if (p_pre->lidar_type == RSM1_BREAK)
+    if (p_pre->lidar_type == RSAIRY)
     {
         msg->angular_velocity.y *= -1.0;
         msg->angular_velocity.z *= -1.0;
@@ -433,25 +456,37 @@ bool sync_packages(MeasureGroup &meas)
     if(!lidar_pushed)
     {
         meas.lidar = lidar_buffer.front();
-        if(p_pre->lidar_type == RSM1){
-            meas.lidar_beg_time = time_buffer.front() - meas.lidar->points.back().curvature / double(1000);
-        }else{
+
+        // for flash lidar with 4 fields (XYZI), the timestamp is the same for all points, so we can directly use the header time as both start and end time of the scan. 
+        // For other lidars, we need to calculate the start time based on the curvature field of the last point, which records the time offset of that point relative to the scan start time.
+        if (p_pre->lidar_type == RSAIRY && msg_is_XYZI)
+        {
+            // Flash lidar capture is instantaneous. Start and end times are identical.
             meas.lidar_beg_time = time_buffer.front();
-        }
-        if (meas.lidar->points.size() <= 1) // time too little
-        {
-            lidar_end_time = meas.lidar_beg_time + lidar_mean_scantime;
-            ROS_WARN("Too few input point cloud!\n");
-        }
-        else if (meas.lidar->points.back().curvature / double(1000) < 0.5 * lidar_mean_scantime)
-        {
-            lidar_end_time = meas.lidar_beg_time + lidar_mean_scantime;
+            lidar_end_time = meas.lidar_beg_time; 
         }
         else
         {
-            scan_num ++;
-            lidar_end_time = meas.lidar_beg_time + meas.lidar->points.back().curvature / double(1000);
-            lidar_mean_scantime += (meas.lidar->points.back().curvature / double(1000) - lidar_mean_scantime) / scan_num;
+            if(p_pre->lidar_type == RSM1){
+                meas.lidar_beg_time = time_buffer.front() - meas.lidar->points.back().curvature / double(1000);
+            }else{
+                meas.lidar_beg_time = time_buffer.front();
+            }
+            if (meas.lidar->points.size() <= 1) // time too little
+            {
+                lidar_end_time = meas.lidar_beg_time + lidar_mean_scantime;
+                ROS_WARN("Too few input point cloud!\n");
+            }
+            else if (meas.lidar->points.back().curvature / double(1000) < 0.5 * lidar_mean_scantime)
+            {
+                lidar_end_time = meas.lidar_beg_time + lidar_mean_scantime;
+            }
+            else
+            {
+                scan_num ++;
+                lidar_end_time = meas.lidar_beg_time + meas.lidar->points.back().curvature / double(1000);
+                lidar_mean_scantime += (meas.lidar->points.back().curvature / double(1000) - lidar_mean_scantime) / scan_num;
+            }
         }
 
         meas.lidar_end_time = lidar_end_time;
@@ -881,6 +916,7 @@ int main(int argc, char** argv)
     nh.param<string>("common/lid_topic",lid_topic,"/livox/lidar");
     nh.param<string>("common/imu_topic", imu_topic,"/livox/imu");
     nh.param<bool>("common/time_sync_en", time_sync_en, false);
+    nh.param<bool>("common/deskew_en", deskew_en, true);
     nh.param<double>("common/time_offset_lidar_to_imu", time_diff_lidar_to_imu, 0.0);
     nh.param<double>("filter_size_corner",filter_size_corner_min,0.5);
     nh.param<double>("filter_size_surf",filter_size_surf_min,0.5);
@@ -892,6 +928,7 @@ int main(int argc, char** argv)
     nh.param<double>("mapping/acc_cov",acc_cov,0.1);
     nh.param<double>("mapping/b_gyr_cov",b_gyr_cov,0.0001);
     nh.param<double>("mapping/b_acc_cov",b_acc_cov,0.0001);
+    nh.param<bool>("mapping/divide_sub_cloud", p_pre->divide_sub_cloud, false);
     nh.param<int>("mapping/num_sub_cloud", num_sub_cloud, 1);
     nh.param<double>("mapping/max_search_dist_surf", max_search_dist_surf, 5);
     nh.param<double>("preprocess/blind", p_pre->blind, 0.01);
@@ -911,6 +948,7 @@ int main(int argc, char** argv)
     
     path.header.stamp    = ros::Time::now();
     path.header.frame_id ="camera_init";
+    ROS_INFO("--- LiDAR type: %d, Divide into %d sub-clouds: %s", p_pre->lidar_type, num_sub_cloud, p_pre->divide_sub_cloud ? "true" : "false");
 
     /*** variables definition ***/
     int effect_feat_num = 0, frame_num = 0;
@@ -931,8 +969,8 @@ int main(int argc, char** argv)
 
     Lidar_T_wrt_IMU<<VEC_FROM_ARRAY(extrinT);
     Lidar_R_wrt_IMU<<MAT_FROM_ARRAY(extrinR);
-    // for RSAIRY, the lidar frame is NED, need to change to FLU
-    if (p_pre->lidar_type == RSM1_BREAK)
+    // for RSAIRY, the lidar frame is NED, need to change to FLU for the IEKF to work properly
+    if (p_pre->lidar_type == RSAIRY)
     {
         M3D NED_to_FLU;
         NED_to_FLU << 1, 0, 0,

--- a/src/laserMapping.cpp
+++ b/src/laserMapping.cpp
@@ -973,10 +973,15 @@ int main(int argc, char** argv)
     if (p_pre->lidar_type == RSAIRY)
     {
         M3D NED_to_FLU;
-        NED_to_FLU << 1, 0, 0,
-                    0,-1, 0,
-                    0, 0,-1;
-        Lidar_R_wrt_IMU *= NED_to_FLU;
+        NED_to_FLU << 1,  0,  0,
+                    0, -1,  0,
+                    0,  0, -1;
+                    
+        // Left-multiply to transform the output into the FLU frame
+        Lidar_R_wrt_IMU = NED_to_FLU * Lidar_R_wrt_IMU; 
+        
+        // Apply the same transformation to the translation vector
+        Lidar_T_wrt_IMU = NED_to_FLU * Lidar_T_wrt_IMU; 
     }
 
     p_imu->set_extrinsic(Lidar_T_wrt_IMU, Lidar_R_wrt_IMU);

--- a/src/preprocess.cpp
+++ b/src/preprocess.cpp
@@ -34,9 +34,10 @@ Preprocess::Preprocess()
 
 Preprocess::~Preprocess() {}
 
-void Preprocess::set(bool feat_en, int lid_type, double bld, int pfilt_num)
+void Preprocess::set(bool feat_en, bool divide_sub_cloud, int lid_type, double bld, int pfilt_num)
 {
   feature_enabled = feat_en;
+  divide_sub_cloud = divide_sub_cloud;
   lidar_type = lid_type;
   blind = bld;
   point_filter_num = pfilt_num;
@@ -84,8 +85,8 @@ void Preprocess::process(const sensor_msgs::PointCloud2::ConstPtr &msg, PointClo
     robosenseM1_handler(msg, i_sub_cloud, num_sub_cloud, start_time, end_time);
     break;
 
-  case RSM1_BREAK:
-    robosenseM1_handler(msg, i_sub_cloud, num_sub_cloud, start_time, end_time);
+  case RSAIRY:
+    robosenseAiry_handler(msg, i_sub_cloud, num_sub_cloud, start_time, end_time);
     break;
 
   default:
@@ -427,7 +428,69 @@ void Preprocess::robosenseM1_handler(const sensor_msgs::PointCloud2::ConstPtr &m
      //pub_func(pl_surf, pub_full, msg->header.stamp);
      pub_func(pl_surf, pub_corn, msg->header.stamp);
 }
+void Preprocess::robosenseAiry_handler(const sensor_msgs::PointCloud2::ConstPtr &msg, 
+                                       int i_sub_cloud, int num_sub_cloud, 
+                                       double &start_time, double &end_time)
+{
+    // if message type is XYZIRT, use robosenseM1_handler 
+    if (msg->fields.size() >= 6){
+      robosenseM1_handler(msg, i_sub_cloud, num_sub_cloud, start_time, end_time);
+      return;
+    }
+    
+    pl_surf.clear();
+    pl_corn.clear();
+    pl_full.clear();
+    
+    // 1. Extract raw XYZI data into a Ptr (required for the VoxelGrid filter)
+    pcl::PointCloud<pcl::PointXYZI>::Ptr pl_orig(new pcl::PointCloud<pcl::PointXYZI>());
+    pcl::fromROSMsg(*msg, *pl_orig);
+    
+    if (pl_orig->points.empty()) return;
 
+    // 2. Set timestamps (treating the solid-state flash as instantaneous)
+    start_time = msg->header.stamp.toSec();
+    end_time = start_time;
+
+    // 3. Apply the Voxel Grid Downsampling
+    pcl::PointCloud<pcl::PointXYZI>::Ptr pl_downsampled(new pcl::PointCloud<pcl::PointXYZI>());
+    pcl::VoxelGrid<pcl::PointXYZI> voxel_filter;
+    voxel_filter.setInputCloud(pl_orig);
+    
+    // Set the voxel size (e.g., 0.1m x 0.1m x 0.1m). 
+    // You can adjust this based on how dense you want the SLAM map.
+    voxel_filter.setLeafSize(0.1f, 0.1f, 0.1f); 
+    voxel_filter.filter(*pl_downsampled);
+
+    // 4. Process the downsampled points into FAST_LIO's PointType
+    for (const auto& ori_point : pl_downsampled->points)
+    {
+        double range = sqrt(ori_point.x * ori_point.x + 
+                            ori_point.y * ori_point.y + 
+                            ori_point.z * ori_point.z);
+                            
+        // Filter out points that are too close (blind spot) or too far
+        if (range < 60 && range > blind)
+        {
+            PointType added_pt;
+            added_pt.x = ori_point.x;
+            added_pt.y = ori_point.y;
+            added_pt.z = ori_point.z;
+            added_pt.intensity = ori_point.intensity;
+            added_pt.normal_x = 0;
+            added_pt.normal_y = 0;
+            added_pt.normal_z = 0;
+            
+            // No deskewing time offset for solid-state
+            added_pt.curvature = 0.0; 
+
+            pl_surf.points.push_back(added_pt);
+        }
+    }
+    
+    // 5. Publish to the rest of the FAST_LIO pipeline
+    pub_func(pl_surf, pub_corn, msg->header.stamp);
+}
 void Preprocess::velodyne_handler(const sensor_msgs::PointCloud2::ConstPtr &msg)
 {
     pl_surf.clear();

--- a/src/preprocess.cpp
+++ b/src/preprocess.cpp
@@ -4,7 +4,7 @@
 #define RETURN0AND1 0x10
 
 Preprocess::Preprocess()
-  :feature_enabled(0), lidar_type(AVIA), blind(0.01), point_filter_num(1)
+  :feature_enabled(0), lidar_type(AVIA), blind(0.01), det_range(100.0), max_height(5.0), point_filter_num(1)
 {
   inf_bound = 10;
   N_SCANS   = 6;
@@ -34,12 +34,14 @@ Preprocess::Preprocess()
 
 Preprocess::~Preprocess() {}
 
-void Preprocess::set(bool feat_en, bool divide_sub_cloud, int lid_type, double bld, int pfilt_num)
+void Preprocess::set(bool feat_en, bool divide_sub_cloud, int lid_type, double bld, double max_range, double max_z, int pfilt_num)
 {
   feature_enabled = feat_en;
   divide_sub_cloud = divide_sub_cloud;
   lidar_type = lid_type;
   blind = bld;
+  det_range = max_range;
+  max_height = max_z;
   point_filter_num = pfilt_num;
 }
 
@@ -270,7 +272,7 @@ void Preprocess::oust64_handler(const sensor_msgs::PointCloud2::ConstPtr &msg)
 
       double range = pl_orig.points[i].x * pl_orig.points[i].x + pl_orig.points[i].y * pl_orig.points[i].y + pl_orig.points[i].z * pl_orig.points[i].z;
       
-      if (range < (blind * blind) || range  > 100 * 100) continue;
+      if (range < (blind * blind) || range > det_range * det_range) continue;
       
       Eigen::Vector3d pt_vec;
       PointType added_pt;
@@ -325,8 +327,9 @@ void Preprocess::robosenseM1_handler(const sensor_msgs::PointCloud2::ConstPtr &m
                 }
                 if (i_ori_height % point_filter_num != 0) {continue;}
 
-                double range = ori_point.x * ori_point.x + ori_point.y * ori_point.y + ori_point.z * ori_point.z;
-                if(sqrt(range) < 150 && sqrt(range) > blind){
+                double range = sqrt(ori_point.x * ori_point.x + ori_point.y * ori_point.y + ori_point.z * ori_point.z);
+                bool height_valid = ori_point.z < max_height && ori_point.z > 0;
+                if(range < det_range && range > blind && height_valid){
 
                     Eigen::Vector3d pt_vec;
                     PointType added_pt;
@@ -401,7 +404,8 @@ void Preprocess::robosenseM1_handler(const sensor_msgs::PointCloud2::ConstPtr &m
 //                } else if(range> 0) {
 //                    if (i_ori_height % 10 != 0) { continue; }
 //                }
-                if(range < 150 && range > blind){
+                bool height_valid = ori_point.z < max_height && ori_point.z > 0;
+                if(range < det_range && range > blind && height_valid){
 
                     Eigen::Vector3d pt_vec;
                     PointType added_pt;
@@ -454,9 +458,9 @@ void Preprocess::robosenseAiry_handler(const sensor_msgs::PointCloud2::ConstPtr 
 
     // 3. Apply the Voxel Grid Downsampling
     pcl::PointCloud<pcl::PointXYZI>::Ptr pl_downsampled(new pcl::PointCloud<pcl::PointXYZI>());
-    pcl::VoxelGrid<pcl::PointXYZI> voxel_filter;
+    pcl::ApproximateVoxelGrid<pcl::PointXYZI> voxel_filter;
     voxel_filter.setInputCloud(pl_orig);
-    
+
     // Set the voxel size (e.g., 0.1m x 0.1m x 0.1m). 
     // You can adjust this based on how dense you want the SLAM map.
     voxel_filter.setLeafSize(0.1f, 0.1f, 0.1f); 
@@ -470,7 +474,9 @@ void Preprocess::robosenseAiry_handler(const sensor_msgs::PointCloud2::ConstPtr 
                             ori_point.z * ori_point.z);
                             
         // Filter out points that are too close (blind spot) or too far
-        if (range < 60 && range > blind)
+        // Filter out points that are above max height or below 0 (assuming the LiDAR is mounted above the ground)
+        bool height_valid = ori_point.z < max_height && ori_point.z > 0;
+        if(range < det_range && range > blind && height_valid)
         {
             PointType added_pt;
             added_pt.x = ori_point.x;

--- a/src/preprocess.h
+++ b/src/preprocess.h
@@ -2,6 +2,7 @@
 #include <pcl_conversions/pcl_conversions.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <livox_ros_driver/CustomMsg.h>
+#include <pcl/filters/voxel_grid.h>
 
 using namespace std;
 
@@ -10,7 +11,7 @@ using namespace std;
 typedef pcl::PointXYZINormal PointType;
 typedef pcl::PointCloud<PointType> PointCloudXYZI;
 
-enum LID_TYPE{AVIA = 1, VELO16, OUST64, RSM1, RSM1_BREAK}; //{1, 2, 3} RSM1: robosense M1 lidar, RSM1_BREAK: break the scan into smaller sub-scan
+enum LID_TYPE{AVIA = 1, VELO16, OUST64, RSM1, RSAIRY}; //{1, 2, 3, 4, 5} RSM1: robosense M1 lidar, RSAIRY: robosense Airy lidar
 enum TIME_UNIT{SEC = 0, MS = 1, US = 2, NS = 3};
 enum Feature{Nor, Poss_Plane, Real_Plane, Edge_Jump, Edge_Plane, Wire, ZeroPoint};
 enum Surround{Prev, Next};
@@ -111,7 +112,7 @@ class Preprocess
   void process(const livox_ros_driver::CustomMsg::ConstPtr &msg, PointCloudXYZI::Ptr &pcl_out);
   void process(const sensor_msgs::PointCloud2::ConstPtr &msg, PointCloudXYZI::Ptr &pcl_out,
                int i_sub_cloud, int num_sub_cloud, double & start_time, double & end_time);
-  void set(bool feat_en, int lid_type, double bld, int pfilt_num);
+  void set(bool feat_en, bool divide_sub_cloud, int lid_type, double bld, int pfilt_num);
 
   // sensor_msgs::PointCloud2::ConstPtr pointcloud;
   PointCloudXYZI pl_full, pl_corn, pl_surf;
@@ -120,7 +121,7 @@ class Preprocess
   float time_unit_scale;
   int lidar_type, point_filter_num, N_SCANS, SCAN_RATE, time_unit;
   double blind;
-  bool feature_enabled, given_offset_time;
+  bool feature_enabled, given_offset_time, divide_sub_cloud{false};
   ros::Publisher pub_full, pub_surf, pub_corn;
     
 
@@ -128,6 +129,7 @@ class Preprocess
   void avia_handler(const livox_ros_driver::CustomMsg::ConstPtr &msg);
   void oust64_handler(const sensor_msgs::PointCloud2::ConstPtr &msg);
   void robosenseM1_handler(const sensor_msgs::PointCloud2::ConstPtr &msg, int i_sub_cloud, int num_sub_cloud, double & start_time, double & end_time);
+  void robosenseAiry_handler(const sensor_msgs::PointCloud2::ConstPtr &msg, int i_sub_cloud, int num_sub_cloud, double & start_time, double & end_time);
   void velodyne_handler(const sensor_msgs::PointCloud2::ConstPtr &msg);
   void give_feature(PointCloudXYZI &pl, vector<orgtype> &types);
   void pub_func(PointCloudXYZI &pl, const ros::Publisher publisher, const ros::Time &ct);

--- a/src/preprocess.h
+++ b/src/preprocess.h
@@ -2,7 +2,7 @@
 #include <pcl_conversions/pcl_conversions.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <livox_ros_driver/CustomMsg.h>
-#include <pcl/filters/voxel_grid.h>
+#include <pcl/filters/approximate_voxel_grid.h>
 
 using namespace std;
 
@@ -112,7 +112,7 @@ class Preprocess
   void process(const livox_ros_driver::CustomMsg::ConstPtr &msg, PointCloudXYZI::Ptr &pcl_out);
   void process(const sensor_msgs::PointCloud2::ConstPtr &msg, PointCloudXYZI::Ptr &pcl_out,
                int i_sub_cloud, int num_sub_cloud, double & start_time, double & end_time);
-  void set(bool feat_en, bool divide_sub_cloud, int lid_type, double bld, int pfilt_num);
+  void set(bool feat_en, bool divide_sub_cloud, int lid_type, double bld, double max_range, double max_z, int pfilt_num);
 
   // sensor_msgs::PointCloud2::ConstPtr pointcloud;
   PointCloudXYZI pl_full, pl_corn, pl_surf;
@@ -120,7 +120,7 @@ class Preprocess
   vector<orgtype> typess[128]; //maximum 128 line lidar
   float time_unit_scale;
   int lidar_type, point_filter_num, N_SCANS, SCAN_RATE, time_unit;
-  double blind;
+  double blind, det_range, max_height;
   bool feature_enabled, given_offset_time, divide_sub_cloud{false};
   ros::Publisher pub_full, pub_surf, pub_corn;
     


### PR DESCRIPTION

### Features
This branch adds support for the RS Airy Lidar as additional lidar type `lidar_type: 5`. It is a plug-and-play fix and does not require any conversion node. Also provides a `Dockerfile` and config file `rslidar_sdk_cfg.yaml` for `rslidar_sdk`.
  
- Correct frame convention (FLU) for IEKF to work properly, which avoids drift and frame misalignment.     
- Supports both message types `XYZI` and `XYZIRT` for the RS Airy Lidar.  
- Supports processing sub-clouds only if message type `XYZIRT`. It is enabled/disabled via parameter `divide_sub_cloud`.
- Deskewing can be unabled/disabled via parameter `deskew_en`. 
- Applies height filtering to ignore points above `max_height` (ceiling filter), supported for both RS M1 and Airy Lidars. This avoids processing unnecessary points and reduces overhead.
- Maximum range can be specified as a parameter `det_range`.

### Notes    
a. When data type is `XYZI`:       
- Uses voxel downsampling (PCL) with a voxel size `0.1m x 0.1m x 0.1m`.
- Assumes all points have the same timestamp (curvature = 0) as a flash scan.

b. When data type is `XYZIRT`:     
- Uses `robosenseM1_handler`
- Still applies height filtering

c. Common:
- NED-to-FLU is performed on the IMU data (y and z axis are inverted) and on the IMU-to-Lidar extrinsics.
- Replaced hardcoded detection range with parameters from YAML config.
- Voxel downsampling uses `ApproximateVoxelGrid` for faster downsampling.
- Added a script `extract_packet_data.py` to get Lidar-to-IMU extrinsics from DIFOP packet (from rosbag).